### PR TITLE
Add curl to aztecprotocol/alpine-build-image

### DIFF
--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -1,6 +1,6 @@
 # This build image is used for launching the small docker executor in Circle CI.
 # We only ever use this executor for launching powerful EC2 instances, as it's the cheapest option.
 FROM alpine:latest
-RUN apk add --no-cache python3 py3-pip git openssh-client ca-certificates jq bash \
+RUN apk add --no-cache python3 py3-pip git openssh-client ca-certificates jq bash curl \
     && pip3 install --upgrade pip \
     && pip3 install --no-cache-dir awscli


### PR DESCRIPTION
Use case is pushing CI notifications in aztec3-packages from jobs that depend on this image. See https://github.com/AztecProtocol/aztec3-packages/issues/249.

The size of the image went from 188mb to 188mb, seems like curl is under 1mb.