### PR TITLE
fix: rebuild when check_rebuild fails

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -52,7 +52,7 @@ echo "Last successful commit: $LAST_SUCCESSFUL_COMMIT"
 cd $(query_manifest buildDir $REPOSITORY)
 
 # If we have previously successful commit, we can early out if nothing relevant has changed since.
-if ! check_rebuild "$LAST_SUCCESSFUL_COMMIT" $REPOSITORY; then
+if check_rebuild "$LAST_SUCCESSFUL_COMMIT" $REPOSITORY; then
   echo "No rebuild necessary. Retagging..."
   STAGES=$(cat $DOCKERFILE | sed -n -e 's/^FROM .* AS \(.*\)/\1/p')
   for STAGE in $STAGES; do

--- a/scripts/check_rebuild
+++ b/scripts/check_rebuild
@@ -28,7 +28,7 @@ echo "list_file_diff ${BASE_COMMIT} ${COMMIT_HASH}"
 
 cat `which list_file_diff`
 
-if list_file_diff ${BASE_COMMIT} ${COMMIT_HASH} | grep -f .rebuild_patterns &>/dev/null; then
+if list_file_diff ${BASE_COMMIT} ${COMMIT_HASH} | grep -f .rebuild_patterns; then
   echo "Rebuild required."
   exit 1
 else

--- a/scripts/check_rebuild
+++ b/scripts/check_rebuild
@@ -25,11 +25,10 @@ git config diff.renameLimit 999999
 
 # run list_file_diff, but make sure output goes to console (via tee+stderr)
 # while also being captured in a variable. Exit with a message on failure.
-different_files=$(ls | tee /dev/stderr) || {
+different_files=$(list_file_diff ${BASE_COMMIT} ${COMMIT_HASH} | tee /dev/stderr) || {
   echo "list_file_diff failed. Rebuild required.";
   exit 1;
 }
-
 
 if grep -f .rebuild_patterns <<< "$different_files" &> /dev/null; then
   echo "Rebuild required."

--- a/scripts/check_rebuild
+++ b/scripts/check_rebuild
@@ -33,7 +33,7 @@ echo "list_file_diff output:"
 # use a tee and a temp file to do this
 # if list_file_diff fails, exit with failure
 temp_diff_file=$(mktemp)
-{list_file_diff ${BASE_COMMIT} ${COMMIT_HASH} | tee temp_diff_file; } || { echo "list_file_diff failed"; exit 1; }
+{ list_file_diff ${BASE_COMMIT} ${COMMIT_HASH} | tee "$temp_diff_file"; } || { echo "list_file_diff failed"; exit 1; }
 different_files=$(cat "$temp_diff_file")
 rm "$temp_diff_file"
 

--- a/scripts/check_rebuild
+++ b/scripts/check_rebuild
@@ -7,10 +7,10 @@ set -euo pipefail
 BASE_COMMIT=$1
 REPOSITORY=$2
 
-# If given nothing, then return true to rebuild.
-[ -n "$BASE_COMMIT" ] || exit 0
+# If given nothing, then exit with failure to rebuild
+[ -n "$BASE_COMMIT" ] || exit 1
 
-# If a tainted tag exists, remove it and return true to rebuild.
+# If a tainted tag exists, remove it exit with failure to rebuild.
 if image_exists $REPOSITORY tainted; then
   echo "$REPOSITORY has been tainted. Will rebuild."
   exit 1
@@ -33,9 +33,14 @@ echo "list_file_diff output:"
 # use a tee and a temp file to do this
 # if list_file_diff fails, exit with failure
 temp_diff_file=$(mktemp)
-{ list_file_diff ${BASE_COMMIT} ${COMMIT_HASH} | tee "$temp_diff_file"; } || { echo "list_file_diff failed"; exit 1; }
-different_files=$(cat "$temp_diff_file")
-rm "$temp_diff_file"
+{
+  list_file_diff ${BASE_COMMIT} ${COMMIT_HASH} | tee "$temp_diff_file";
+} || {
+  rm -f "$temp_diff_file";
+  echo "list_file_diff failed. Rebuild required";
+  exit 1;
+}
+different_files=$(cat "$temp_diff_file") && rm "$temp_diff_file"
 
 
 if grep -f .rebuild_patterns <<< "$different_files" &> /dev/null; then

--- a/scripts/check_rebuild
+++ b/scripts/check_rebuild
@@ -24,7 +24,9 @@ cat .rebuild_patterns
 
 git config diff.renameLimit 999999
 
-echo "listing file diff"
+echo "list_file_diff ${BASE_COMMIT} ${COMMIT_HASH}"
+
+cat list_file_diff
 
 if list_file_diff ${BASE_COMMIT} ${COMMIT_HASH} | grep -f .rebuild_patterns &>/dev/null; then
   echo "Rebuild required."

--- a/scripts/check_rebuild
+++ b/scripts/check_rebuild
@@ -28,7 +28,8 @@ echo "list_file_diff ${BASE_COMMIT} ${COMMIT_HASH}"
 
 cat `which list_file_diff`
 
-echo list_file_diff output: `list_file_diff ${BASE_COMMIT} ${COMMIT_HASH}`
+echo "list_file_diff output:"
+list_file_diff ${BASE_COMMIT} ${COMMIT_HASH}
 
 if list_file_diff ${BASE_COMMIT} ${COMMIT_HASH} | grep -f .rebuild_patterns; then
   echo "Rebuild required."

--- a/scripts/check_rebuild
+++ b/scripts/check_rebuild
@@ -19,6 +19,7 @@ fi
 # Compute .rebuild_patterns from the build manifest.
 query_manifest rebuildPatterns $REPOSITORY > .rebuild_patterns
 
+echo "Rebuild patterns:"
 cat .rebuild_patterns
 
 git config diff.renameLimit 999999

--- a/scripts/check_rebuild
+++ b/scripts/check_rebuild
@@ -19,28 +19,16 @@ fi
 # Compute .rebuild_patterns from the build manifest.
 query_manifest rebuildPatterns $REPOSITORY > .rebuild_patterns
 
-echo "Rebuild patterns:"
 cat .rebuild_patterns
 
 git config diff.renameLimit 999999
 
-echo "list_file_diff ${BASE_COMMIT} ${COMMIT_HASH}"
-
-cat `which list_file_diff`
-
-echo "list_file_diff output:"
-# run list_file_diff, but make sure output goes to console and is also captured in a variable
-# use a tee and a temp file to do this
-# if list_file_diff fails, exit with failure
-temp_diff_file=$(mktemp)
-{
-  list_file_diff ${BASE_COMMIT} ${COMMIT_HASH} | tee "$temp_diff_file";
-} || {
-  rm -f "$temp_diff_file";
-  echo "list_file_diff failed. Rebuild required";
+# run list_file_diff, but make sure output goes to console (via tee+stderr)
+# while also being captured in a variable. Exit with a message on failure.
+different_files=$(ls | tee /dev/stderr) || {
+  echo "list_file_diff failed. Rebuild required.";
   exit 1;
 }
-different_files=$(cat "$temp_diff_file") && rm "$temp_diff_file"
 
 
 if grep -f .rebuild_patterns <<< "$different_files" &> /dev/null; then

--- a/scripts/check_rebuild
+++ b/scripts/check_rebuild
@@ -1,5 +1,6 @@
 #!/bin/bash
-# Succeeds if any files matching the rebuild patterns, have changed since the base commit.
+# Fails if any files matching the rebuild patterns, have changed since the base commit.
+# If this script fails (nonzero exit), then the caller should rebuild.
 # The rebuild patterns are taken from the build manifest (computed from set of dependencies).
 set -euo pipefail
 

--- a/scripts/check_rebuild
+++ b/scripts/check_rebuild
@@ -12,7 +12,7 @@ REPOSITORY=$2
 # If a tainted tag exists, remove it and return true to rebuild.
 if image_exists $REPOSITORY tainted; then
   echo "$REPOSITORY has been tainted. Will rebuild."
-  exit 0
+  exit 1
 fi
 
 # Compute .rebuild_patterns from the build manifest.
@@ -24,7 +24,7 @@ cat .rebuild_patterns
 git config diff.renameLimit 999999
 
 if list_file_diff ${BASE_COMMIT} ${COMMIT_HASH} | grep -f .rebuild_patterns &>/dev/null; then
-  exit 0
-else
   exit 1
+else
+  exit 0
 fi

--- a/scripts/check_rebuild
+++ b/scripts/check_rebuild
@@ -29,7 +29,7 @@ echo "list_file_diff ${BASE_COMMIT} ${COMMIT_HASH}"
 cat `which list_file_diff`
 
 echo "list_file_diff output:"
-list_file_diff ${BASE_COMMIT} ${COMMIT_HASH}
+list_file_diff ${BASE_COMMIT} ${COMMIT_HASH} || echo "list_file_diff failed."
 
 if list_file_diff ${BASE_COMMIT} ${COMMIT_HASH} | grep -f .rebuild_patterns; then
   echo "Rebuild required."

--- a/scripts/check_rebuild
+++ b/scripts/check_rebuild
@@ -24,9 +24,8 @@ cat .rebuild_patterns
 
 git config diff.renameLimit 999999
 
-# run list_file_diff, but make sure output goes to console (via tee+stderr)
-# while also being captured in a variable. Exit with a message on failure.
-different_files=$(list_file_diff ${BASE_COMMIT} ${COMMIT_HASH} | tee /dev/stderr) || {
+# Get list of files that differ
+different_files=$(list_file_diff ${BASE_COMMIT} ${COMMIT_HASH}) || {
   echo "list_file_diff failed. Rebuild required.";
   exit 1;
 }

--- a/scripts/check_rebuild
+++ b/scripts/check_rebuild
@@ -26,7 +26,7 @@ git config diff.renameLimit 999999
 
 echo "list_file_diff ${BASE_COMMIT} ${COMMIT_HASH}"
 
-cat list_file_diff
+cat `which list_file_diff`
 
 if list_file_diff ${BASE_COMMIT} ${COMMIT_HASH} | grep -f .rebuild_patterns &>/dev/null; then
   echo "Rebuild required."

--- a/scripts/check_rebuild
+++ b/scripts/check_rebuild
@@ -29,9 +29,16 @@ echo "list_file_diff ${BASE_COMMIT} ${COMMIT_HASH}"
 cat `which list_file_diff`
 
 echo "list_file_diff output:"
-list_file_diff ${BASE_COMMIT} ${COMMIT_HASH} || echo "list_file_diff failed."
+# run list_file_diff, but make sure output goes to console and is also captured in a variable
+# use a tee and a temp file to do this
+# if list_file_diff fails, exit with failure
+temp_diff_file=$(mktemp)
+{list_file_diff ${BASE_COMMIT} ${COMMIT_HASH} | tee temp_diff_file; } || { echo "list_file_diff failed"; exit 1; }
+different_files=$(cat "$temp_diff_file")
+rm "$temp_diff_file"
 
-if list_file_diff ${BASE_COMMIT} ${COMMIT_HASH} | grep -f .rebuild_patterns; then
+
+if grep -f .rebuild_patterns <<< "$different_files" &> /dev/null; then
   echo "Rebuild required."
   exit 1
 else

--- a/scripts/check_rebuild
+++ b/scripts/check_rebuild
@@ -28,6 +28,8 @@ echo "list_file_diff ${BASE_COMMIT} ${COMMIT_HASH}"
 
 cat `which list_file_diff`
 
+echo list_file_diff output: `list_file_diff ${BASE_COMMIT} ${COMMIT_HASH}`
+
 if list_file_diff ${BASE_COMMIT} ${COMMIT_HASH} | grep -f .rebuild_patterns; then
   echo "Rebuild required."
   exit 1

--- a/scripts/check_rebuild
+++ b/scripts/check_rebuild
@@ -24,8 +24,12 @@ cat .rebuild_patterns
 
 git config diff.renameLimit 999999
 
+echo "listing file diff"
+
 if list_file_diff ${BASE_COMMIT} ${COMMIT_HASH} | grep -f .rebuild_patterns &>/dev/null; then
+  echo "Rebuild required."
   exit 1
 else
+  echo "No rebuild required."
   exit 0
 fi

--- a/scripts/cond_spot_run_build
+++ b/scripts/cond_spot_run_build
@@ -15,7 +15,7 @@ echo "Last successful commit: $LAST_SUCCESSFUL_COMMIT"
 
 cd $(query_manifest buildDir $REPOSITORY)
 
-if !check_rebuild "$LAST_SUCCESSFUL_COMMIT" $REPOSITORY; then
+if ! check_rebuild "$LAST_SUCCESSFUL_COMMIT" $REPOSITORY; then
   spot_run_script $SPEC $BUILD_SYSTEM_PATH/remote_build/remote_build $REPOSITORY $@
 else
   echo "No rebuild necessary. Retagging..."

--- a/scripts/cond_spot_run_build
+++ b/scripts/cond_spot_run_build
@@ -15,7 +15,7 @@ echo "Last successful commit: $LAST_SUCCESSFUL_COMMIT"
 
 cd $(query_manifest buildDir $REPOSITORY)
 
-if check_rebuild "$LAST_SUCCESSFUL_COMMIT" $REPOSITORY; then
+if !check_rebuild "$LAST_SUCCESSFUL_COMMIT" $REPOSITORY; then
   spot_run_script $SPEC $BUILD_SYSTEM_PATH/remote_build/remote_build $REPOSITORY $@
 else
   echo "No rebuild necessary. Retagging..."

--- a/scripts/cond_spot_run_script
+++ b/scripts/cond_spot_run_script
@@ -25,7 +25,7 @@ LAST_SUCCESSFUL_COMMIT=$(last_successful_commit $REPOSITORY $SUCCESS_TAG)
 
 echo "Last successful commit for $SUCCESS_TAG: $LAST_SUCCESSFUL_COMMIT"
 
-if !check_rebuild "$LAST_SUCCESSFUL_COMMIT" $REPOSITORY; then
+if ! check_rebuild "$LAST_SUCCESSFUL_COMMIT" $REPOSITORY; then
   spot_run_script $@
   tag_remote_image $REPOSITORY cache-$COMMIT_HASH cache-$COMMIT_HASH-$SUCCESS_TAG
 fi

--- a/scripts/cond_spot_run_script
+++ b/scripts/cond_spot_run_script
@@ -25,7 +25,7 @@ LAST_SUCCESSFUL_COMMIT=$(last_successful_commit $REPOSITORY $SUCCESS_TAG)
 
 echo "Last successful commit for $SUCCESS_TAG: $LAST_SUCCESSFUL_COMMIT"
 
-if check_rebuild "$LAST_SUCCESSFUL_COMMIT" $REPOSITORY; then
+if !check_rebuild "$LAST_SUCCESSFUL_COMMIT" $REPOSITORY; then
   spot_run_script $@
   tag_remote_image $REPOSITORY cache-$COMMIT_HASH cache-$COMMIT_HASH-$SUCCESS_TAG
 fi

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -13,7 +13,7 @@ deploy_ecr $REPOSITORY
 # Bail out if nothing changed.
 LAST_SUCCESSFUL_COMMIT=$(last_successful_commit $REPOSITORY $DEPLOY_TAG-deployed)
 echo "Last successfully deployed commit: $LAST_SUCCESSFUL_COMMIT"
-if ! check_rebuild "$LAST_SUCCESSFUL_COMMIT" $REPOSITORY; then
+if check_rebuild "$LAST_SUCCESSFUL_COMMIT" $REPOSITORY; then
   echo "No changes detected, skipping deployment."
   exit 0
 fi

--- a/scripts/deploy_global
+++ b/scripts/deploy_global
@@ -12,7 +12,7 @@ deploy_ecr $REPOSITORY
 # Bail out if nothing changed.
 LAST_SUCCESSFUL_COMMIT=$(last_successful_commit $REPOSITORY $DEPLOY_TAG-deployed)
 echo "Last successfully deployed commit: $LAST_SUCCESSFUL_COMMIT"
-if ! check_rebuild "$LAST_SUCCESSFUL_COMMIT" $REPOSITORY; then
+if check_rebuild "$LAST_SUCCESSFUL_COMMIT" $REPOSITORY; then
   echo "No changes detected, skipping deployment."
   exit 0
 fi

--- a/scripts/list_file_diff
+++ b/scripts/list_file_diff
@@ -20,6 +20,7 @@ for SUBMODULE_PATH in $(git config --file .gitmodules --get-regexp path | awk '{
   if [ "$(git ls-tree $BASE_COMMIT $SUBMODULE_PATH | awk '{print $2}')" = "tree" ]; then
     # In the base commit, we were not a submodule, and now we are. Output all files as having changed.
     pushd $SUBMODULE_PATH > /dev/null
+    git ls-files | awk "\$0=\"$SUBMODULE_PATH/\"\$0"
     popd > /dev/null
     continue
   fi

--- a/scripts/list_file_diff
+++ b/scripts/list_file_diff
@@ -13,20 +13,36 @@ fi
 
 cd $ROOT_PATH
 
+echo "Listing file diff between $BASE_COMMIT and $COMMIT_HASH"
 git --no-pager diff --name-only ${BASE_COMMIT} ${COMMIT_HASH}
 
+echo "iterating over submodules"
+echo "Specifically $(git config --file .gitmodules --get-regexp path | awk '{ print $2 }')"
+echo "starting..."
+
 for SUBMODULE_PATH in $(git config --file .gitmodules --get-regexp path | awk '{ print $2 }'); do
+  echo "Checking submodule $SUBMODULE_PATH"
   [ -f $SUBMODULE_PATH/.git ] || continue
+  echo "doing an ls-tree..."
+  echo "git ls-tree: $(git ls-tree $BASE_COMMIT $SUBMODULE_PATH | awk '{print $2}')"
   if [ "$(git ls-tree $BASE_COMMIT $SUBMODULE_PATH | awk '{print $2}')" = "tree" ]; then
     # In the base commit, we were not a submodule, and now we are. Output all files as having changed.
     pushd $SUBMODULE_PATH > /dev/null
+    echo "doing an ls-files..."
     git ls-files | awk "\$0=\"$SUBMODULE_PATH/\"\$0"
+    echo "done on that..."
     popd > /dev/null
     continue
   fi
+  echo "more ls-tees..."
   SM_PREV_HASH=$(git ls-tree $BASE_COMMIT $SUBMODULE_PATH | awk '{print $3}')
   SM_CURR_HASH=$(git ls-tree $COMMIT_HASH $SUBMODULE_PATH | awk '{print $3}')
+  echo "pushd $SUBMODULE_PATH"
   pushd $SUBMODULE_PATH > /dev/null
+  echo "diffing"
+  echo "diffing: $(git --no-pager diff --name-only ${SM_PREV_HASH} ${SM_CURR_HASH})"
   git --no-pager diff --name-only ${SM_PREV_HASH} ${SM_CURR_HASH} | awk "\$0=\"$SUBMODULE_PATH/\"\$0"
+  echo "done iter"
   popd > /dev/null
 done
+echo "done list_file_diff"

--- a/scripts/list_file_diff
+++ b/scripts/list_file_diff
@@ -6,14 +6,18 @@ set -euo pipefail
 BASE_COMMIT=$1
 COMMIT_HASH=${2:-HEAD}
 
+echo "Listing file diff between $BASE_COMMIT and $COMMIT_HASH"
+
 if [ -z "$BASE_COMMIT" ]; then
   echo "Usage $0 from_commit [to_commit]"
   exit 1
 fi
 
+echo "cding to $ROOT_PATH"
 cd $ROOT_PATH
 
-echo "Listing file diff between $BASE_COMMIT and $COMMIT_HASH"
+echo "doing a git diff"
+echo "diff: $(git --no-pager diff --name-only ${BASE_COMMIT} ${COMMIT_HASH})"
 git --no-pager diff --name-only ${BASE_COMMIT} ${COMMIT_HASH}
 
 echo "iterating over submodules"

--- a/scripts/list_file_diff
+++ b/scripts/list_file_diff
@@ -1,53 +1,31 @@
 #!/bin/bash
 # Lists files that have changed between two commits, including files in submodules.
 # Needed because `git diff --submodule=diff --name-only` doesn't work as one would hope.
-echo "HERE"
 set -euo pipefail
 
 BASE_COMMIT=$1
 COMMIT_HASH=${2:-HEAD}
-
-echo "Listing file diff between $BASE_COMMIT and $COMMIT_HASH"
 
 if [ -z "$BASE_COMMIT" ]; then
   echo "Usage $0 from_commit [to_commit]"
   exit 1
 fi
 
-echo "cding to $ROOT_PATH"
 cd $ROOT_PATH
 
-echo "doing a git diff"
-echo "diff: $(git --no-pager diff --name-only ${BASE_COMMIT} ${COMMIT_HASH})"
 git --no-pager diff --name-only ${BASE_COMMIT} ${COMMIT_HASH}
 
-echo "iterating over submodules"
-echo "Specifically $(git config --file .gitmodules --get-regexp path | awk '{ print $2 }')"
-echo "starting..."
-
 for SUBMODULE_PATH in $(git config --file .gitmodules --get-regexp path | awk '{ print $2 }'); do
-  echo "Checking submodule $SUBMODULE_PATH"
   [ -f $SUBMODULE_PATH/.git ] || continue
-  echo "doing an ls-tree..."
-  echo "git ls-tree: $(git ls-tree $BASE_COMMIT $SUBMODULE_PATH | awk '{print $2}')"
   if [ "$(git ls-tree $BASE_COMMIT $SUBMODULE_PATH | awk '{print $2}')" = "tree" ]; then
     # In the base commit, we were not a submodule, and now we are. Output all files as having changed.
     pushd $SUBMODULE_PATH > /dev/null
-    echo "doing an ls-files..."
-    git ls-files | awk "\$0=\"$SUBMODULE_PATH/\"\$0"
-    echo "done on that..."
     popd > /dev/null
     continue
   fi
-  echo "more ls-tees..."
   SM_PREV_HASH=$(git ls-tree $BASE_COMMIT $SUBMODULE_PATH | awk '{print $3}')
   SM_CURR_HASH=$(git ls-tree $COMMIT_HASH $SUBMODULE_PATH | awk '{print $3}')
-  echo "pushd $SUBMODULE_PATH"
   pushd $SUBMODULE_PATH > /dev/null
-  echo "diffing"
-  echo "diffing: $(git --no-pager diff --name-only ${SM_PREV_HASH} ${SM_CURR_HASH})"
   git --no-pager diff --name-only ${SM_PREV_HASH} ${SM_CURR_HASH} | awk "\$0=\"$SUBMODULE_PATH/\"\$0"
-  echo "done iter"
   popd > /dev/null
 done
-echo "done list_file_diff"

--- a/scripts/list_file_diff
+++ b/scripts/list_file_diff
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Lists files that have changed between two commits, including files in submodules.
 # Needed because `git diff --submodule=diff --name-only` doesn't work as one would hope.
+echo "HERE"
 set -euo pipefail
 
 BASE_COMMIT=$1


### PR DESCRIPTION
This is better because if any nested calls/scripts fail check_rebuild will also fail. We want to rebuild if a nested call (like `list_file_diff` fails.

This PR also modifies the nested call to `list_file_diff` so that its failures are captured.