### PR TITLE
feat: Kill spot instance requests

### DIFF
--- a/scripts/request_spot
+++ b/scripts/request_spot
@@ -43,6 +43,9 @@ if [ -z "$IID" -o "$IID" == "None" ]; then
     --cli-input-json file://$BUILD_SYSTEM_PATH/remote/${CPUS}core.json \
     --query "Instances[*].[InstanceId]" \
     --output text)
+else
+  # Write down spot request ID so we can cancel once we finish
+  echo $SIR > sir-$NAME.txt
 fi
 
 aws ec2 create-tags --resources $IID --tags "Key=Name,Value=$NAME"

--- a/scripts/spot_run_script
+++ b/scripts/spot_run_script
@@ -19,4 +19,11 @@ CODE=$?
 echo "Terminating spot instance..."
 ssh -F $SSH_CONFIG_PATH $IP sudo halt -p > /dev/null 2>&1
 
+# Kill spot request so it doesn't count against quota.
+if [ -f "sir-$COMMIT_HASH:$JOB_NAME.txt" ]; then
+    SIR=$(cat sir-$COMMIT_HASH:$JOB_NAME.txt)
+    echo "Cancelling spot instance request $SIR"
+    aws ec2 cancel-spot-instance-requests --spot-instance-request-ids $SIR > /dev/null
+fi
+
 exit $CODE


### PR DESCRIPTION
Cancels spot instance requests at the end of `spot_run_script` to prevent them from counting against quota. We have been getting the following error in our CI:
```
An error occurred (MaxSpotInstanceCountExceeded) when calling the RequestSpotInstances operation: Max spot instance count exceeded
```

And [this answer](https://stackoverflow.com/a/54538652) hints at spot requests not closed. So let's see if this fixes it.