### PR TITLE
feat: ignore _ suffixed docker layers

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -79,9 +79,9 @@ if [ -d $ROOT_PATH/$PROJECT_DIR/terraform ]; then
   popd
 fi
 
-# Pull latest parents that are not ours.
+# Pull latest parents that are not ours. We also do not want to pull images suffixed by _, this is how we scope intermediate build images.
 echo "$DOCKERHUB_PASSWORD" | docker login -u aztecprotocolci --password-stdin
-PARENTS=$(cat $DOCKERFILE | sed -n -e 's/^FROM \([^[:space:]]\+\).*/\1/p' | grep -v $ECR_DEPLOY_URL | sort | uniq)
+PARENTS=$(cat $DOCKERFILE | sed -n -e 's/^FROM \([^[:space:]]\+\).*/\1/p' | sed '/_$/d' | grep -v $ECR_DEPLOY_URL  | sort | uniq)
 for PARENT in $PARENTS; do
   fetch_image $PARENT
 done


### PR DESCRIPTION
## Description

**The issue**
The build script currently looks for any images that look like the following:
```
FROM <name>
```
and pulls them.
When using multistep builds, the build script would try to pull the image for  `builder` as it was used in `FROM builder`. 

**The solution**  
This pr tells the build system to NOT pull images that are suffixed with `_`, now if we want to use multistage builds that build on images created within the current dockerfile, we can use something like `builder_`.


Next steps:
- Should the build system attempt to pre fetch these images? Will docker not automatically attempt to fetch them?